### PR TITLE
Add files via upload

### DIFF
--- a/wUSDT.json
+++ b/wUSDT.json
@@ -1,0 +1,15 @@
+{
+  "chainId": 101,
+  "address": "57GajvDHazpCCCCpKgiHppJJf5cjwHWancCZZLPoeFMj",
+  "symbol": "wUSDT",
+  "name": "Wrapped USDT(Wormhole)",
+  "decimals": 6,
+  "logoURI": "https://bafkreic6tov6v3chg45jkjrhodt4hoerdo26bgqbvrqh6tugyiy6krll4u.ipfs.w3s.link",
+  "tags": ["stablecoin", "wrapped"],
+  "extensions": {
+    "website": "https://wrappedusdt.carrd.co/",
+    "twitter": "https://x.com/wrappedwusdt",
+    "telegram": "https://t.me/WUSDT_SOL",
+    "github": "https://github.com/wusdt-sol"
+  }
+}


### PR DESCRIPTION
# Add Wrapped USDT (wUSDT) token on Solana

This PR adds Wrapped USDT (wUSDT), a wrapped version of Tether (USD₮) on the Solana blockchain.

- Token Mint Address: 57GajvDHazpCCCCpKgiHppJJf5cjwHWancCZZLPoeFMj
- Symbol: wUSDT
- Decimals: 6
- Website: https://wrappedusdt.carrd.co/
- Twitter: https://x.com/wrappedwusdt
- Telegram: https://t.me/WUSDT_SOL
- Github: https://github.com/wusdt-sol
- Logo hosted on IPFS (https://bafkreic6tov6v3chg45jkjrhodt4hoerdo26bgqbvrqh6tugyiy6krll4u.ipfs.w3s.link)

This token enables seamless bridging of USDT to Solana ecosystem.

Thank you for reviewing!
